### PR TITLE
Add basic math solver and chatbot scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # math_chatbot
-This chatbot solve math questions. 
+
+A simple FastAPI-based chatbot that solves math questions step by step. It can
+accept direct text questions or extract math problems from uploaded PDF or image
+files.
+
+## Setup
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running
+
+Start the web server:
+
+```bash
+uvicorn app:app --reload
+```
+
+## Usage
+
+- `POST /solve` with JSON `{ "question": "x + 1 = 3" }`
+- `POST /upload` with a PDF or image file containing a math problem

--- a/app.py
+++ b/app.py
@@ -1,0 +1,35 @@
+"""Minimal FastAPI app for the math chatbot.
+
+FastAPI is optional; if it's not installed the module will still import but the
+web API won't be available.
+"""
+
+try:  # pragma: no cover - optional dependency
+    from fastapi import FastAPI, File, UploadFile
+except Exception:  # pragma: no cover - optional dependency
+    FastAPI = None  # type: ignore
+    File = UploadFile = None  # type: ignore
+
+from solver import solve_equation
+from extractors import extract_text_from_pdf, extract_text_from_image
+import io
+
+if FastAPI:
+    app = FastAPI(title="Math Chatbot")
+
+    @app.post("/solve")
+    async def solve(question: dict):
+        text = question.get("question", "")
+        return solve_equation(text)
+
+    @app.post("/upload")
+    async def upload(file: UploadFile = File(...)):
+        data = await file.read()
+        buf = io.BytesIO(data)
+        if file.filename.lower().endswith(".pdf"):
+            text = extract_text_from_pdf(buf)
+        else:
+            text = extract_text_from_image(buf)
+        return solve_equation(text)
+else:
+    app = None

--- a/extractors.py
+++ b/extractors.py
@@ -1,0 +1,25 @@
+from typing import BinaryIO
+
+
+def extract_text_from_pdf(file: BinaryIO) -> str:
+    """Extract text from a PDF file object using PyPDF2 if available."""
+    try:
+        from PyPDF2 import PdfReader  # type: ignore
+    except Exception as exc:  # pragma: no cover - optional
+        raise RuntimeError("PyPDF2 is required for PDF extraction") from exc
+
+    reader = PdfReader(file)
+    text = "".join(page.extract_text() or "" for page in reader.pages)
+    return text.strip()
+
+
+def extract_text_from_image(file: BinaryIO) -> str:
+    """Extract text from an image file object using pytesseract if available."""
+    try:
+        from PIL import Image  # type: ignore
+        import pytesseract  # type: ignore
+    except Exception as exc:  # pragma: no cover - optional
+        raise RuntimeError("pytesseract and Pillow are required for image OCR") from exc
+
+    img = Image.open(file)
+    return pytesseract.image_to_string(img)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+fastapi
+uvicorn
+sympy
+PyPDF2
+pytesseract
+Pillow
+reportlab
+python-multipart

--- a/solver.py
+++ b/solver.py
@@ -1,0 +1,25 @@
+import re
+from typing import Dict, List
+
+
+def solve_equation(equation: str) -> Dict[str, List[float]]:
+    """Solve a linear equation of the form ax + b = c and show steps.
+
+    Only supports single variable equations with integer coefficients.
+    """
+    equation = equation.replace(" ", "")
+    pattern = r"^([+-]?\d*)x([+-]\d+)?=([+-]?\d+)$"
+    match = re.fullmatch(pattern, equation)
+    if not match:
+        raise ValueError("Equation must be in the form ax + b = c")
+
+    a_str, b_str, c_str = match.groups()
+    a = int(a_str) if a_str not in ("", "+", "-") else (1 if a_str in ("", "+") else -1)
+    b = int(b_str.replace(" ", "")) if b_str else 0
+    c = int(c_str)
+
+    steps = [f"Original equation: {a}x + {b} = {c}"]
+    steps.append(f"Subtract {b} from both sides: {a}x = {c - b}")
+    steps.append(f"Divide both sides by {a}: x = {(c - b)/a}")
+    solution = [(c - b)/a]
+    return {"steps": steps, "solution": solution}

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -1,0 +1,12 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from solver import solve_equation
+
+
+def test_solve_equation():
+    result = solve_equation("2x + 1 = 5")
+    assert result["solution"][0] == 2.0
+    assert result["steps"][0].startswith("Original equation")


### PR DESCRIPTION
## Summary
- implement simple linear equation solver with step-by-step output
- add optional file text extraction utilities and FastAPI app scaffolding
- document setup and usage

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `pytest tests/test_solver.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_68a77b0d48e4832b9c9bd5aba887c1e1